### PR TITLE
feat(task): centralize task creation via unified modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,22 +22,11 @@
             </div>
             <div id="dateText"></div>
         </div>
-        <form>
-            <input type="text" name="taskText" autocomplete="off" placeholder="New Task" class="roundBorder" data-i18n-key="taskPlaceholder">
-            <div class="priority-wrapper">
-                <label for="taskPriority" data-i18n-key="priorityLabel">Prioridad:</label>
-                <select name="taskPriority" id="taskPriority" class="roundBorder">
-                    <option value="high" data-i18n-key="priorityHigh">High</option>
-                    <option value="medium" selected data-i18n-key="priorityMedium">Medium</option>
-                    <option value="low" data-i18n-key="priorityLow">Low</option>
-                </select>
-            </div>
-            <div class="date-wrapper">
-                <label for="taskDate" data-i18n-key="dateLabel">Fecha:</label>
-                <input type="date" name="taskDate" id="taskDate" class="roundBorder" data-i18n-key="datePlaceholder" required>
-            </div>
-            <button type="submit" class="addTaskButton">+</button>
-        </form>
+        <div class="new-task-button-wrapper">
+            <button type="button" id="openNewTaskModal" class="newTaskMainButton roundBorder">
+                <span class="plus-icon">+</span> <span data-i18n-key="newTaskButton">New Task</span>
+            </button>
+        </div>
         <div class="orderButton-wrapper">
             <button type="button" class="orderButton roundBorder" data-i18n-key="orderButton">Order</button>
             <button type="button" class="filterButton roundBorder" data-i18n-key="filterButtonToday">Focus Mode</button>
@@ -50,6 +39,32 @@
         <div id="tasksContainer"></div>
         <div class="donate-wrapper">
             <button type="button" id="donateButton" class="roundBorder" data-i18n-key="donateButton">Donate</button>
+        </div>
+    </div>
+
+    <div id="newTaskModal" class="modal">
+        <div class="modal-content roundBorder">
+            <span class="close-button" id="closeNewTaskModal">&times;</span>
+            <h2 data-i18n-key="newTaskTitle">New Task</h2>
+            <form id="newTaskForm">
+                <input type="text" name="taskText" autocomplete="off" placeholder="New Task" class="roundBorder" data-i18n-key="taskPlaceholder">
+                <div class="priority-wrapper">
+                    <label for="taskPriority" data-i18n-key="priorityLabel">Priority:</label>
+                    <select name="taskPriority" id="taskPriority" class="roundBorder">
+                        <option value="high" data-i18n-key="priorityHigh">High</option>
+                        <option value="medium" selected data-i18n-key="priorityMedium">Medium</option>
+                        <option value="low" data-i18n-key="priorityLow">Low</option>
+                    </select>
+                </div>
+                <div class="date-wrapper">
+                    <label for="taskDate" data-i18n-key="dateLabel">Date:</label>
+                    <input type="date" name="taskDate" id="taskDate" class="roundBorder" data-i18n-key="datePlaceholder" required>
+                </div>
+                <div class="modal-actions">
+                    <button type="submit" class="orderButton roundBorder" data-i18n-key="addButton">Add</button>
+                    <button type="button" id="cancelNewTaskButton" class="filterButton roundBorder" data-i18n-key="cancelButton">Cancel</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -36,6 +36,9 @@ export const translations = {
         editTaskTitle: 'Edit Task',
         saveButton: 'Save',
         cancelButton: 'Cancel',
+        newTaskButton: 'New Task',
+        newTaskTitle: 'New Task',
+        addButton: 'Add',
     },
     es: {
         pageTitle: 'Lista de Tareas',
@@ -70,6 +73,9 @@ export const translations = {
         editTaskTitle: 'Editar Tarea',
         saveButton: 'Guardar',
         cancelButton: 'Cancelar',
+        newTaskButton: 'Nueva Tarea',
+        newTaskTitle: 'Nueva Tarea',
+        addButton: 'Añadir',
     }
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (editDateInput) editDateInput.min = minDate;
 
     // ── 5. Event listeners del formulario y botones globales ─
-    document.querySelector('form').addEventListener('submit', addNewTask);
+    document.getElementById('newTaskForm').addEventListener('submit', addNewTask);
 
     document.querySelector('.orderButton')
         .addEventListener('click', renderOrderedTasks);

--- a/js/modalManager.js
+++ b/js/modalManager.js
@@ -16,6 +16,20 @@ let currentEditingWrapper  = null;
  */
 export const initModalManager = (container) => { tasksContainer = container; };
 
+// ─── Modal de nueva tarea ──────────────────────────────────
+
+export const openNewTaskModal = () => {
+    document.getElementById('newTaskModal').style.display = 'block';
+    // Enfocar el input automáticamente
+    setTimeout(() => {
+        document.querySelector('#newTaskForm input[name="taskText"]').focus();
+    }, 10);
+};
+
+export const closeNewTaskModal = () => {
+    document.getElementById('newTaskModal').style.display = 'none';
+};
+
 // ─── Modal de edición ──────────────────────────────────────
 
 export const openEditModal = (event) => {
@@ -84,6 +98,12 @@ export const saveModalChanges = (event) => {
  * y los botones de copiar cripto.
  */
 export const initModals = () => {
+    // New Task
+    const newTaskModal = document.getElementById('newTaskModal');
+    document.getElementById('openNewTaskModal').onclick    = openNewTaskModal;
+    document.getElementById('closeNewTaskModal').onclick   = closeNewTaskModal;
+    document.getElementById('cancelNewTaskButton').onclick = closeNewTaskModal;
+
     // Donate
     const donateModal = document.getElementById('donateModal');
     document.getElementById('donateButton').onclick          = () => donateModal.style.display = 'block';
@@ -97,8 +117,9 @@ export const initModals = () => {
     // Cerrar al hacer click fuera del modal
     const editModal = document.getElementById('editModal');
     window.addEventListener('click', (e) => {
-        if (e.target === donateModal) donateModal.style.display = 'none';
-        if (e.target === editModal)   closeEditModal();
+        if (e.target === donateModal)  donateModal.style.display = 'none';
+        if (e.target === editModal)    closeEditModal();
+        if (e.target === newTaskModal) closeNewTaskModal();
     });
 
     // Botones de copiar cripto

--- a/js/taskManager.js
+++ b/js/taskManager.js
@@ -8,6 +8,7 @@ import { formatDisplayDate, isoStringToDate,
          isDateInPast, shouldResetRecurringTask } from './dateUtils.js';
 import { readTasks, persistFromDOM }        from './storage.js';
 import { createTaskElement, initRenderer }  from './taskRenderer.js';
+import { closeNewTaskModal }                from './modalManager.js';
 
 export const VALID_PRIORITIES = ['high', 'medium', 'low'];
 
@@ -82,6 +83,7 @@ export const addNewTask = (event) => {
     tasksContainer.prepend(buildTaskElement(value.trim(), date, priority, [], 'none', null));
     event.target.reset();
     persistFromDOM(tasksContainer);
+    closeNewTaskModal();
 };
 
 /**

--- a/style.css
+++ b/style.css
@@ -89,6 +89,51 @@ body {
     font-family: 'Poppins', sans-serif;
 }
 
+.new-task-button-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 25px;
+}
+
+.newTaskMainButton {
+    background-color: var(--btnplus);
+    color: white;
+    border: none;
+    padding: 12px 30px;
+    font-size: 1.1rem;
+    font-family: 'Poppins', sans-serif;
+    font-weight: 700;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: transform 0.2s, box-shadow 0.2s, background-color 0.3s;
+    box-shadow: 0 4px 15px rgba(255, 101, 132, 0.3);
+}
+
+.newTaskMainButton:hover {
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 6px 20px rgba(255, 101, 132, 0.4);
+    background-color: #ff4d70;
+}
+
+.newTaskMainButton .plus-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+#newTaskForm {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
+    margin-top: 20px;
+}
+
+#newTaskForm input[name="taskText"] {
+    width: 90%;
+}
+
 #dateNumber {
     font-size: 3.5rem;
     font-weight: 700;
@@ -159,28 +204,6 @@ input:focus {
 
 input[type="date"]::-webkit-calendar-picker-indicator {
     filter: invert(1);
-}
-
-/* Botón flotante para agregar tarea */
-.addTaskButton {
-    background-color: var(--btnplus);
-    color: white;
-    font-size: 24px;
-    width: 45px;
-    height: 45px;
-    border-radius: 50%;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 10px;
-    transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.addTaskButton:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 10px rgba(0,0,0,0.15);
 }
 
 /* Contenedores de botones */


### PR DESCRIPTION
- Replaced direct form submission with a prominent New Task button in the main index.
- Implemented a new centralized modal (#newTaskModal) consistent with existing edit and donate modals.
- Updated CSS styles to include modern transitions and removed deprecated floating button styles.
- Added logic to auto-focus the input field upon opening and reset the form after successful save.
- Synced event listeners in main.js and modalManager.js to handle the new workflow.
- Added new translations (ES/EN) for the task creation flow in i18n.js.