### PR TITLE
fix(date handling): update year format to 4-digit and correct recurre…

### DIFF
--- a/js/dateUtils.js
+++ b/js/dateUtils.js
@@ -19,7 +19,7 @@ export const getLocaleKey = () => {
  * @returns {string}
  */
 export const formatDisplayDate = (date) =>
-    date.toLocaleDateString(getLocaleKey(), { day: '2-digit', month: '2-digit', year: '2-digit' });
+    date.toLocaleDateString(getLocaleKey(), { day: '2-digit', month: '2-digit', year: 'numeric' });
 
 /**
  * Convierte el string ISO de un <input type="date"> ('yyyy-mm-dd')
@@ -52,7 +52,7 @@ export const isDateInPast = (date) => {
 export const displayDateToIso = (displayDate) => {
     const parts = displayDate.split('/');
     if (parts.length !== 3) return '';
-    const year = '20' + parts[2];
+    const year = parts[2];
     const lang = getLang();
     const [day, month] = lang === 'es'
         ? [parts[0].padStart(2, '0'), parts[1].padStart(2, '0')]

--- a/js/taskManager.js
+++ b/js/taskManager.js
@@ -70,7 +70,7 @@ export const loadTasks = () => {
     tasks.forEach(task => {
         if (typeof task.text !== 'string' || typeof task.done !== 'boolean') return;
 
-        const date      = task.date ?? formatDisplayDate(new Date());
+        let date      = task.date ?? formatDisplayDate(new Date());
         const priority  = task.priority ?? 'medium';
         const subtasks  = task.subtasks ?? [];
         const recurrence = task.recurrence ?? 'none';
@@ -82,7 +82,8 @@ export const loadTasks = () => {
                 done = false;
                 lastCompleted = null;
                 // Update date to today for recurring tasks that are being reset
-                task.date = formatDisplayDate(new Date());
+                date = formatDisplayDate(new Date());
+                task.date = date;
             }
         }
 


### PR DESCRIPTION
…nce reset

- Enforce 4-digit year display (YYYY) while maintaining locale-specific order (dd/mm vs mm/dd).
- Updated displayDateToIso to process 4-digit years when editing tasks.
- Fixed recurring task reset in js/taskManager.js to update to the current day instead of old dates.